### PR TITLE
Parse map(k1,v1,k2,v2) from hive to trino

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.trino.rel2trino;
 
 import org.apache.calcite.config.NullCollation;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
@@ -31,6 +32,17 @@ public class TrinoSqlDialect extends SqlDialect {
 
   public void unparseOffsetFetch(SqlWriter writer, SqlNode offset, SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
+  }
+
+  @Override
+  public void unparseCall(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    switch (call.getOperator().kind) {
+      case MAP_VALUE_CONSTRUCTOR:
+        unparseMapOperator(writer, call, leftPrec, rightPrec);
+        break;
+      default:
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+    }
   }
 
   @Override
@@ -61,5 +73,27 @@ public class TrinoSqlDialect extends SqlDialect {
 
   public boolean requireCastOnString() {
     return true;
+  }
+
+  private void unparseMapOperator(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    writer.keyword(call.getOperator().getName()); // "MAP"
+    final SqlWriter.Frame frame = writer.startList("(", ")");
+    writer.keyword("ARRAY[");
+    // Even numbers are keys
+    for (int i = 0; i < call.operandCount(); i += 2) {
+      writer.sep(",");
+      call.operand(i).unparse(writer, leftPrec, rightPrec);
+    }
+    writer.keyword("], ARRAY[");
+    // Odd numbers are values
+    for (int i = 1; i < call.operandCount(); i += 2) {
+      call.operand(i).unparse(writer, leftPrec, rightPrec);
+      // Last comma is redundant
+      if (i < call.operandCount() - 1) {
+        writer.sep(",");
+      }
+    }
+    writer.keyword("]");
+    writer.endList(frame);
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -130,6 +130,8 @@ public class HiveToTrinoConverterTest {
             + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"t0\"" },
 
-        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" } };
+        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" },
+
+        { "test", "map_array_view", "SELECT MAP (ARRAY[ 'key1', 'key2' ], ARRAY[ 'value1', 'value2']) AS \"col_map\"\nFROM \"test\".\"tablea\"" } };
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -282,6 +282,8 @@ public class TestUtils {
         + "SELECT `t`.`a`, `jt`.`d`, `jt`.`e`, `jt`.`f` FROM `test`.`tableA` AS `t` LATERAL VIEW json_tuple(`t`.`b`.`b1`, \"trino\", \"always\", \"rocks\") `jt` AS `d`, `e`, `f`");
     run(driver, "CREATE VIEW IF NOT EXISTS test.get_json_object_view AS \n"
         + "SELECT get_json_object(b.b1, '$.name') FROM test.tableA");
+    run(driver, "CREATE VIEW IF NOT EXISTS test.map_array_view AS \n"
+        + "SELECT MAP('key1', 'value1', 'key2', 'value2') AS col_map FROM test.tableA");
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
For hive, SELECT MAP(k1, v1, k2, v2) is

{k1=v1, k2=v2};

but for trino, sql should be SELECT MAP(ARRAY[k1,k2], ARRAY[v1,v2])